### PR TITLE
Fix pong paddles

### DIFF
--- a/containers/vuejs/src/components/GameSocket.ts
+++ b/containers/vuejs/src/components/GameSocket.ts
@@ -13,29 +13,10 @@ export const setupGameSocket = (render: (data: any) => void) => {
       })
       socket.on('pong', (data: any) => {
         render(data)
-        console.log(data)
       })
       socket.on('disconnect', () => {
         disconnect()
         console.log('Disconnected')
-      })
-      document.addEventListener('keydown', (event) => {
-        const keyName = event.key
-        console.log(keyName)
-        if (socket) {
-          socket.emit('pressed', keyName)
-        } else {
-          console.log('No socket')
-        }
-      })
-      document.addEventListener('keyup', (event) => {
-        const keyName = event.key
-        console.log(keyName)
-        if (socket) {
-          socket.emit('released', keyName)
-        } else {
-          console.log('No socket')
-        }
       })
     }
   }
@@ -51,7 +32,7 @@ export const setupGameSocket = (render: (data: any) => void) => {
       north = false
     }
     if (north !== undefined) {
-      socket.emit('movePaddle', { code, keydown })
+      socket.emit('movePaddle', { keydown: keydown, north: north })
     } else {
       console.log('No socket')
     }


### PR DESCRIPTION
[This PR](https://github.com/MyNameIsTrez/transcendence/pull/12/files) broke the paddles, this fixes them again.

I did this by removing the `keydown` and `keyup` logic from GameSocket.ts, since it was an old, invalid version, and because it clashed with Pong.vue that already handled that logic correctly.