### PR TITLE
Another pong game

### DIFF
--- a/containers/nestjs/src/game/APong.ts
+++ b/containers/nestjs/src/game/APong.ts
@@ -238,7 +238,6 @@ export class Ball extends Rect {
 
   collideWithBorder(leftPlayer: Player, rightPlayer: Player): Sides {
     if (this.left <= 0 || this.right >= WINDOW_WIDTH) {
-      // TODO: Make return value retrieval better
       if (this.left <= 0) {
         return Sides.Left;
       } else {
@@ -249,7 +248,6 @@ export class Ball extends Rect {
     if (this.top <= 0 || this.bottom >= WINDOW_HEIGHT) {
       this._pos.y = this.top < 0 ? 0 : WINDOW_HEIGHT - this._size.h;
       this._vel.invertdY();
-      // TODO: Make return value retrieval better
       if (this.top <= 0) {
         return Sides.Top;
       } else {

--- a/containers/nestjs/src/game/APong.ts
+++ b/containers/nestjs/src/game/APong.ts
@@ -264,11 +264,12 @@ class Ball extends Rect {
   // }
 }
 
-export default class Pong {
+export abstract class APong {
   _winScore: number;
   _ball: Ball;
   _leftPlayer: Player;
   _rightPlayer: Player;
+  type: string = 'APong';
 
   constructor(winScore: number) {
     this._winScore = winScore;
@@ -280,14 +281,6 @@ export default class Pong {
 
     this._leftPlayer = new Player(PADDLE_LEFT_X);
     this._rightPlayer = new Player(PADDLE_RIGHT_X);
-  }
-
-  update() {
-    this._leftPlayer.update();
-    this._rightPlayer.update();
-
-    this._ball.updatePos();
-    this._ball.collide(this._leftPlayer, this._rightPlayer);
   }
 
   didSomeoneWin(): boolean {
@@ -306,45 +299,12 @@ export default class Pong {
     return this.didLeftWin() ? 0 : 1;
   }
 
-  // TODO: Use?
-  // resetGame() {
-  //   this._ball._hidden = false;
-  //   this._ball.reset();
-  //   this._leftPlayer._score = 0;
-  //   this._rightPlayer._score = 0;
-  // }
-
-  getData() {
-    return {
-      ball: {
-        pos: this._ball._pos,
-        size: this._ball._size,
-      },
-      leftPlayer: {
-        score: this._leftPlayer._score,
-        paddle: {
-          pos: this._leftPlayer.paddle._pos,
-          size: this._leftPlayer.paddle._size,
-        },
-      },
-      rightPlayer: {
-        score: this._rightPlayer._score,
-        paddle: {
-          pos: this._rightPlayer.paddle._pos,
-          size: this._rightPlayer.paddle._size,
-        },
-      },
-    };
-  }
-
   movePaddle(playerIndex: number, keydown: boolean, north: boolean) {
     const paddle = this.getPlayer(playerIndex)?.paddle;
     if (paddle) {
       if (north) {
-        console.log('Moving north');
         paddle.dyNorth = keydown ? -10 : 0;
       } else {
-        console.log('Moving south');
         paddle.dySouth = keydown ? 10 : 0;
       }
     }
@@ -356,4 +316,7 @@ export default class Pong {
     }
     return playerIndex == 0 ? this._leftPlayer : this._rightPlayer;
   }
+
+  abstract update(): void;
+  abstract getData(): any;
 }

--- a/containers/nestjs/src/game/APong.ts
+++ b/containers/nestjs/src/game/APong.ts
@@ -83,8 +83,15 @@ export class Velocity {
   set len(value: number) {
     {
       const fact = value / this.len;
-      this._dx *= fact;
-      this._dy *= fact;
+      // The if statement is put here to prevent the ball from gaining too much speed and going through the player paddle
+      if (this._dx * fact <= 25) {
+        this._dx *= fact;
+        this._dy *= fact;
+      } else {
+        const num: number = 25 / this._dx;
+        this._dx *= num;
+        this._dy;
+      }
     }
   }
   adjustAngle(multiplier: number) {

--- a/containers/nestjs/src/game/APong.ts
+++ b/containers/nestjs/src/game/APong.ts
@@ -82,15 +82,15 @@ export class Velocity {
   }
   set len(value: number) {
     {
-      const fact = value / this.len;
+      let fact = value / this.len;
       // The if statement is put here to prevent the ball from gaining too much speed and going through the player paddle
       if (this._dx * fact <= 25) {
         this._dx *= fact;
         this._dy *= fact;
       } else {
-        const num: number = 25 / this._dx;
-        this._dx *= num;
-        this._dy;
+        fact = 25 / this._dx;
+        this._dx *= fact;
+        this._dy *= fact;
       }
     }
   }

--- a/containers/nestjs/src/game/Lobby.ts
+++ b/containers/nestjs/src/game/Lobby.ts
@@ -1,8 +1,9 @@
 import { ConfigService } from '@nestjs/config';
 import { Server, Socket } from 'socket.io';
 import { v4 as uuid } from 'uuid';
-import NormalPong from './NormalPong';
 import { APong } from './APong';
+import NormalPong from './NormalPong';
+import SpecialPong from './SpecialPong';
 
 export default class Lobby {
   public readonly id: string = uuid();
@@ -15,6 +16,7 @@ export default class Lobby {
 
   private readonly gamemodes: Map<string, Function> = new Map([
     ['normal', (scoreToWin: number) => new NormalPong(scoreToWin)],
+    ['special', (scoreToWin: number) => new SpecialPong(scoreToWin)],
   ]);
 
   private gameHasStarted = false;

--- a/containers/nestjs/src/game/LobbyManager.ts
+++ b/containers/nestjs/src/game/LobbyManager.ts
@@ -13,7 +13,7 @@ export default class LobbyManager {
     private configService: ConfigService,
   ) {}
 
-  public queue(client: Socket) {
+  public queue(client: Socket, mode: string) {
     if (
       this.isUserAlreadyInLobby(client.data) &&
       this.configService.get('DEBUG') == 0
@@ -22,7 +22,7 @@ export default class LobbyManager {
       throw new WsException('Already in a lobby');
     }
 
-    const lobby = this.getLobby();
+    const lobby = this.getLobby(mode);
     lobby.addClient(client);
     this.lobbies.set(lobby.id, lobby);
     client.data.lobby = lobby;
@@ -39,16 +39,17 @@ export default class LobbyManager {
   // and checking if the last lobby only has 1 player.
   // This is because join() could accidentally join the wrong lobby
   // if it took a lobby_index instead of a lobby_id.
-  private getLobby(): Lobby {
+  private getLobby(mode: string): Lobby {
+    // TODO: Update this to look for corrrect gamemode lobby
     const notFullLobby = Array.from(this.lobbies.values()).find(
-      (lobby) => !lobby.isFull(),
+      (lobby) => lobby.getPong().type === mode && !lobby.isFull(),
     );
     if (notFullLobby) {
       console.log("Found a lobby that wasn't full");
       return notFullLobby;
     }
 
-    const newLobby = new Lobby(this.server, this.configService);
+    const newLobby = new Lobby(mode, this.server, this.configService);
     this.lobbies.set(newLobby.id, newLobby);
     console.log('Created a new lobby');
     return newLobby;

--- a/containers/nestjs/src/game/NormalPong.ts
+++ b/containers/nestjs/src/game/NormalPong.ts
@@ -1,0 +1,47 @@
+import { APong } from './APong';
+
+export default class NormalPong extends APong {
+  constructor(winScore: number) {
+    super(winScore);
+    this.type = 'normal';
+  }
+
+  update() {
+    this._leftPlayer.update();
+    this._rightPlayer.update();
+
+    this._ball.updatePos();
+    this._ball.collide(this._leftPlayer, this._rightPlayer);
+  }
+
+  // TODO: Use?
+  // resetGame() {
+  //   this._ball._hidden = false;
+  //   this._ball.reset();
+  //   this._leftPlayer._score = 0;
+  //   this._rightPlayer._score = 0;
+  // }
+
+  getData() {
+    return {
+      ball: {
+        pos: this._ball._pos,
+        size: this._ball._size,
+      },
+      leftPlayer: {
+        score: this._leftPlayer._score,
+        paddle: {
+          pos: this._leftPlayer.paddle._pos,
+          size: this._leftPlayer.paddle._size,
+        },
+      },
+      rightPlayer: {
+        score: this._rightPlayer._score,
+        paddle: {
+          pos: this._rightPlayer.paddle._pos,
+          size: this._rightPlayer.paddle._size,
+        },
+      },
+    };
+  }
+}

--- a/containers/nestjs/src/game/NormalPong.ts
+++ b/containers/nestjs/src/game/NormalPong.ts
@@ -1,4 +1,4 @@
-import { APong } from './APong';
+import { APong, Sides } from './APong';
 
 export default class NormalPong extends APong {
   constructor(winScore: number) {
@@ -11,24 +11,36 @@ export default class NormalPong extends APong {
     this._rightPlayer.update();
 
     this._ball.updatePos();
-    this._ball.collide(this._leftPlayer, this._rightPlayer);
+    this.collidedWithBorder = this._ball.collide(
+      this._leftPlayer,
+      this._rightPlayer,
+    );
+    if (this.collidedWithBorder == Sides.Left) {
+      this._rightPlayer.addPoint();
+      this.reset();
+      return;
+    } else if (this.collidedWithBorder == Sides.Right) {
+      this._leftPlayer.addPoint();
+      this.reset();
+      return;
+    }
   }
 
   getData() {
     return {
       rects: [
         {
-          color: 'white',
+          color: this._leftPlayer.paddle._color,
           pos: this._leftPlayer.paddle._pos,
           size: this._leftPlayer.paddle._size,
         },
         {
-          color: 'white',
+          color: this._rightPlayer.paddle._color,
           pos: this._rightPlayer.paddle._pos,
           size: this._rightPlayer.paddle._size,
         },
         {
-          color: 'yellow',
+          color: this._ball._color,
           pos: this._ball._pos,
           size: this._ball._size,
         },
@@ -38,5 +50,8 @@ export default class NormalPong extends APong {
         rightPlayer: this._rightPlayer._score,
       },
     };
+  }
+  reset(): void {
+    this._ball.reset();
   }
 }

--- a/containers/nestjs/src/game/NormalPong.ts
+++ b/containers/nestjs/src/game/NormalPong.ts
@@ -14,33 +14,28 @@ export default class NormalPong extends APong {
     this._ball.collide(this._leftPlayer, this._rightPlayer);
   }
 
-  // TODO: Use?
-  // resetGame() {
-  //   this._ball._hidden = false;
-  //   this._ball.reset();
-  //   this._leftPlayer._score = 0;
-  //   this._rightPlayer._score = 0;
-  // }
-
   getData() {
     return {
-      ball: {
-        pos: this._ball._pos,
-        size: this._ball._size,
-      },
-      leftPlayer: {
-        score: this._leftPlayer._score,
-        paddle: {
+      rects: [
+        {
+          color: 'white',
           pos: this._leftPlayer.paddle._pos,
           size: this._leftPlayer.paddle._size,
         },
-      },
-      rightPlayer: {
-        score: this._rightPlayer._score,
-        paddle: {
+        {
+          color: 'white',
           pos: this._rightPlayer.paddle._pos,
           size: this._rightPlayer.paddle._size,
         },
+        {
+          color: 'yellow',
+          pos: this._ball._pos,
+          size: this._ball._size,
+        },
+      ],
+      score: {
+        leftPlayer: this._leftPlayer._score,
+        rightPlayer: this._rightPlayer._score,
       },
     };
   }

--- a/containers/nestjs/src/game/SpecialPong.ts
+++ b/containers/nestjs/src/game/SpecialPong.ts
@@ -119,7 +119,10 @@ export default class SpecialPong extends APong {
     this.type = 'special';
   }
 
-  private _lastBallDirection: Velocity = new Velocity(0, 0);
+  private readonly _availableItems: Array<Function> = [
+    (x: number, y: number) => new ReverseControlItem(x, y),
+    (x: number, y: number) => new invisibleBallItem(x, y),
+  ];
   private _itemsOnMap: Array<Item> = [];
   private _itemsPickedUp: Array<Item> = [];
 
@@ -194,7 +197,11 @@ export default class SpecialPong extends APong {
       // 1/4 chance to spawn an item
       if (Math.random() <= 0.25) {
         const pos = Item.generateRandomPos();
-        this._itemsOnMap.push(new ReverseControlItem(pos.x, pos.y));
+        this._itemsOnMap.push(
+          this._availableItems[
+            Math.floor(Math.random() * this._availableItems.length)
+          ](pos.x, pos.y),
+        );
       }
     }
   }
@@ -233,11 +240,12 @@ export default class SpecialPong extends APong {
   }
 
   reset(): void {
-    this._ball.reset();
-    this._lastBallDirection._dx = 0;
-    this._lastBallDirection._dy = 0;
-    this._itemsOnMap = [];
+    for (const item of this._itemsPickedUp) {
+      item.onItemEnd(this);
+    }
     this._itemsPickedUp = [];
+    this._itemsOnMap = [];
+    this._ball.reset();
     this.collidedWithBorder = Sides.None;
   }
 }

--- a/containers/nestjs/src/game/SpecialPong.ts
+++ b/containers/nestjs/src/game/SpecialPong.ts
@@ -46,12 +46,6 @@ abstract class Item extends Rect {
   abstract onItemEnd(game: APong): void;
 }
 
-// Item Ideas:
-// V Reverse opponent controls for a few rounds
-// V Ball invisible from pickup to first bounce
-// - Move opponent a little bit forward for a few rounds
-// V Make opponent paddle a bit smaller for a few rounds
-
 class ReverseControlItem extends Item {
   constructor(x: number, y: number) {
     super(x, y, 'purple');

--- a/containers/nestjs/src/game/SpecialPong.ts
+++ b/containers/nestjs/src/game/SpecialPong.ts
@@ -31,8 +31,10 @@ abstract class Item extends Rect {
   static standardSize: Size = { w: 35, h: 35 };
 
   static generateRandomPos(): Pos {
-    const xMinCeiled = Math.ceil((WINDOW_WIDTH / 3) * 2 - WINDOW_WIDTH / 3);
-    const xMaxFloored = Math.floor(WINDOW_WIDTH / 3 - Item.standardSize.w);
+    const xMinCeiled = Math.ceil(WINDOW_WIDTH / 3);
+    const xMaxFloored = Math.floor(
+      (WINDOW_WIDTH / 3) * 2 - Item.standardSize.w,
+    );
     const x = Math.random() * (xMaxFloored - xMinCeiled) + xMinCeiled;
     const y = Math.random() * (WINDOW_HEIGHT - Item.standardSize.h);
     return { x, y };

--- a/containers/nestjs/src/game/SpecialPong.ts
+++ b/containers/nestjs/src/game/SpecialPong.ts
@@ -120,13 +120,16 @@ class invisibleBallItem extends Item {
   private static readonly _originalBallColor = 'white';
 
   onItemPickup(itemOwnerId: number): void {}
+
   hookFunction(game: APong): boolean {
     game._ball._color = 'transparent';
     return true;
   }
+
   onPaddleHit(game: APong): boolean {
     return false;
   }
+  
   onItemEnd(game: APong): void {
     game._ball._color = invisibleBallItem._originalBallColor;
   }

--- a/containers/nestjs/src/game/SpecialPong.ts
+++ b/containers/nestjs/src/game/SpecialPong.ts
@@ -106,7 +106,7 @@ class ReverseControlItem extends Item {
   }
 }
 
-class invisibleBallItem extends Item {
+class InvisibleBallItem extends Item {
   constructor(x: number, y: number) {
     super(x, y, 'silver');
   }
@@ -125,11 +125,11 @@ class invisibleBallItem extends Item {
   }
 
   onItemEnd(game: APong): void {
-    game._ball._color = invisibleBallItem._originalBallColor;
+    game._ball._color = InvisibleBallItem._originalBallColor;
   }
 }
 
-class smallerPaddleItem extends Item {
+class SmallerPaddleItem extends Item {
   constructor(x: number, y: number) {
     super(x, y, 'pink');
   }
@@ -180,8 +180,8 @@ export default class SpecialPong extends APong {
 
   private readonly _availableItems: Array<Function> = [
     (x: number, y: number) => new ReverseControlItem(x, y),
-    (x: number, y: number) => new invisibleBallItem(x, y),
-    (x: number, y: number) => new smallerPaddleItem(x, y),
+    (x: number, y: number) => new InvisibleBallItem(x, y),
+    (x: number, y: number) => new SmallerPaddleItem(x, y),
   ];
   private _itemsOnMap: Array<Item> = [];
   private _itemsPickedUp: Array<Item> = [];

--- a/containers/nestjs/src/game/SpecialPong.ts
+++ b/containers/nestjs/src/game/SpecialPong.ts
@@ -163,16 +163,10 @@ export default class SpecialPong extends APong {
       return;
     }
 
-    // TODO: Comment
     // If ball hits paddle
-    // console.log(
-    //   'this._lastBallDirection.dx > 0 ? 0 : 1',
-    //   this._lastBallDirection.dx,
-    // );
-    // console.log('==> this._ball._vel.dx > 0 ? 0 : 1', this._ball._vel.dx);
     if (
-      (this._lastBallDirection.dx > 0 ? 0 : 1) !=
-      (this._ball._vel.dx > 0 ? 0 : 1)
+      this.collidedWithBorder === Sides.LeftPaddle ||
+      this.collidedWithBorder === Sides.RightPaddle
     ) {
       // 1/4 chance to spawn an item
       if (Math.random() <= 0.25) {

--- a/containers/nestjs/src/game/SpecialPong.ts
+++ b/containers/nestjs/src/game/SpecialPong.ts
@@ -48,8 +48,7 @@ abstract class Item extends Rect {
 
 // Item Ideas:
 // V Reverse opponent controls for a few rounds
-// - Ball invisible from pickup to first bounce
-// - Split ball into 2 (one back on forward), can only spawn on opponent side and persists until end of round
+// V Ball invisible from pickup to first bounce
 // - Move opponent a little bit forward for a few rounds
 // - Make opponent paddle a bit smaller for a few rounds
 
@@ -113,6 +112,26 @@ class ReverseControlItem extends Item {
   }
 }
 
+class invisibleBallItem extends Item {
+  constructor(x: number, y: number) {
+    super(x, y, 'silver');
+  }
+
+  private static readonly _originalBallColor = 'white';
+
+  onItemPickup(itemOwnerId: number): void {}
+  hookFunction(game: APong): boolean {
+    game._ball._color = 'transparent';
+    return true;
+  }
+  onPaddleHit(game: APong): boolean {
+    return false;
+  }
+  onItemEnd(game: APong): void {
+    game._ball._color = invisibleBallItem._originalBallColor;
+  }
+}
+
 export default class SpecialPong extends APong {
   constructor(winScore: number) {
     super(winScore);
@@ -127,9 +146,6 @@ export default class SpecialPong extends APong {
   private _itemsPickedUp: Array<Item> = [];
 
   update() {
-    this._lastBallDirection._dx = this._ball._vel._dx;
-    this._lastBallDirection._dy = this._ball._vel._dy;
-
     // Update the ball position
     this._ball.updatePos();
 

--- a/containers/nestjs/src/game/SpecialPong.ts
+++ b/containers/nestjs/src/game/SpecialPong.ts
@@ -1,0 +1,226 @@
+import {
+  APong,
+  Ball,
+  Player,
+  Pos,
+  Rect,
+  Sides,
+  Size,
+  Velocity,
+  WINDOW_HEIGHT,
+  WINDOW_WIDTH,
+} from './APong';
+
+abstract class Item extends Rect {
+  constructor(x: number, y: number, c: string) {
+    super(Item.standardSize.w, Item.standardSize.h, x, y, c);
+  }
+
+  collidesWithBall(ball: Ball): boolean {
+    if (
+      this.left <= ball.right &&
+      this.right >= ball.left &&
+      this.bottom >= ball.top &&
+      this.top <= ball.bottom
+    ) {
+      return true;
+    }
+    return false;
+  }
+
+  static standardSize: Size = { w: 35, h: 35 };
+
+  static generateRandomPos(): Pos {
+    const xMinCeiled = Math.ceil((WINDOW_WIDTH / 3) * 2 - WINDOW_WIDTH / 3);
+    const xMaxFloored = Math.floor(WINDOW_WIDTH / 3 - Item.standardSize.w);
+    const x = Math.random() * (xMaxFloored - xMinCeiled) + xMinCeiled;
+    const y = Math.random() * (WINDOW_HEIGHT - Item.standardSize.h);
+    return { x, y };
+  }
+
+  abstract onItemPickup(itemOwnerId: number): void;
+  abstract hookFunction(game: APong): boolean;
+}
+
+// Item Ideas:
+// V Reverse opponent controls for a few rounds
+// - Ball invisible from pickup to first bounce
+// - Split ball into 2 (one back on forward), can only spawn on opponent side and persists until end of round
+// - Move opponent a little bit forward for a few rounds
+// - Make opponent paddle a bit smaller for a few rounds
+
+class ReverseControlItem extends Item {
+  constructor(x: number, y: number) {
+    super(x, y, 'purple');
+  }
+
+  private _affectedPlayerId: number;
+  private _remainingTurns: number = 3;
+
+  onItemPickup(itemOwnerId: number): void {
+    // Set affectedPlayerId to opponent id
+    this._affectedPlayerId = 1 - itemOwnerId;
+  }
+
+  hookFunction(game: APong): boolean {
+    if (game._leftPlayer.id === this._affectedPlayerId) {
+      if (game.collidedWithBorder === Sides.LeftPaddle) {
+        this._remainingTurns--;
+        if (this._remainingTurns === 0) {
+          game._leftPlayer.paddle._color = 'white';
+          return false;
+        }
+      }
+      game._leftPlayer.paddle._color = 'purple';
+      game._leftPlayer.paddle.dyNorth = Math.max(
+        game._leftPlayer.paddle.dyNorth * -1,
+        game._leftPlayer.paddle.dyNorth,
+      );
+      game._leftPlayer.paddle.dySouth = Math.min(
+        game._leftPlayer.paddle.dySouth * -1,
+        game._leftPlayer.paddle.dySouth,
+      );
+    } else {
+      if (game.collidedWithBorder === Sides.RightPaddle) {
+        this._remainingTurns--;
+        if (this._remainingTurns === 0) {
+          game._rightPlayer.paddle._color = 'white';
+          return false;
+        }
+      }
+      game._rightPlayer.paddle._color = 'purple';
+      game._rightPlayer.paddle.dyNorth = Math.max(
+        game._rightPlayer.paddle.dyNorth * -1,
+        game._rightPlayer.paddle.dyNorth,
+      );
+      game._rightPlayer.paddle.dySouth = Math.min(
+        game._rightPlayer.paddle.dySouth * -1,
+        game._rightPlayer.paddle.dySouth,
+      );
+    }
+    return true;
+  }
+}
+
+export default class SpecialPong extends APong {
+  constructor(winScore: number) {
+    super(winScore);
+    this.type = 'special';
+  }
+
+  private _lastBallDirection: Velocity = new Velocity(0, 0);
+  private _itemsOnMap: Array<Item> = [];
+  private _itemsPickedUp: Array<Item> = [];
+
+  update() {
+    this._lastBallDirection._dx = this._ball._vel._dx;
+    this._lastBallDirection._dy = this._ball._vel._dy;
+
+    // Update the ball position
+    this._ball.updatePos();
+
+    // Check if any items were picked up
+    for (let i: number = 0; i < this._itemsOnMap.length; i++) {
+      const item: Item = this._itemsOnMap[i];
+      if (item.collidesWithBall(this._ball)) {
+        // Decides who should be the item owner
+        const id = this._ball._vel.dx > 0 ? 0 : 1;
+        item.onItemPickup(id);
+        this._itemsPickedUp.push(item);
+        this._itemsOnMap.splice(i, i + 1);
+        // To accommodate for the i++ that happens in the for loop while all the items gets pushed to the left because of the splice()
+        i--;
+      }
+    }
+
+    // Do item effects of picked up items
+    for (let i: number = 0; i < this._itemsPickedUp.length; i++) {
+      const item: Item = this._itemsPickedUp[i];
+      const doesItemContinue: boolean = item.hookFunction(this);
+      if (!doesItemContinue) {
+        this._itemsPickedUp.splice(i, i + 1);
+        // To accommodate for the i++ that happens in the for loop while all the items gets pushed to the left because of the splice()
+        i--;
+      }
+    }
+
+    // Update player paddles positions
+    this._leftPlayer.update();
+    this._rightPlayer.update();
+
+    // Check if the ball colided with a player
+    this.collidedWithBorder = this._ball.collide(
+      this._leftPlayer,
+      this._rightPlayer,
+    );
+    if (this.collidedWithBorder == Sides.Left) {
+      this._rightPlayer.addPoint();
+      this.reset();
+      return;
+    } else if (this.collidedWithBorder == Sides.Right) {
+      this._leftPlayer.addPoint();
+      this.reset();
+      return;
+    }
+
+    // TODO: Comment
+    // If ball hits paddle
+    // console.log(
+    //   'this._lastBallDirection.dx > 0 ? 0 : 1',
+    //   this._lastBallDirection.dx,
+    // );
+    // console.log('==> this._ball._vel.dx > 0 ? 0 : 1', this._ball._vel.dx);
+    if (
+      (this._lastBallDirection.dx > 0 ? 0 : 1) !=
+      (this._ball._vel.dx > 0 ? 0 : 1)
+    ) {
+      // 1/4 chance to spawn an item
+      if (Math.random() <= 0.25) {
+        const pos = Item.generateRandomPos();
+        this._itemsOnMap.push(new ReverseControlItem(pos.x, pos.y));
+      }
+    }
+  }
+
+  getData() {
+    let rects: Array<any> = [];
+    rects.push({
+      color: this._leftPlayer.paddle._color,
+      pos: this._leftPlayer.paddle._pos,
+      size: this._leftPlayer.paddle._size,
+    });
+    rects.push({
+      color: this._rightPlayer.paddle._color,
+      pos: this._rightPlayer.paddle._pos,
+      size: this._rightPlayer.paddle._size,
+    });
+    rects.push({
+      color: this._ball._color,
+      pos: this._ball._pos,
+      size: this._ball._size,
+    });
+    for (const item of this._itemsOnMap) {
+      rects.push({
+        color: item._color,
+        pos: item._pos,
+        size: item._size,
+      });
+    }
+    return {
+      rects,
+      score: {
+        leftPlayer: this._leftPlayer._score,
+        rightPlayer: this._rightPlayer._score,
+      },
+    };
+  }
+
+  reset(): void {
+    this._ball.reset();
+    this._lastBallDirection._dx = 0;
+    this._lastBallDirection._dy = 0;
+    this._itemsOnMap = [];
+    this._itemsPickedUp = [];
+    this.collidedWithBorder = Sides.None;
+  }
+}

--- a/containers/nestjs/src/game/game.gateway.ts
+++ b/containers/nestjs/src/game/game.gateway.ts
@@ -70,8 +70,11 @@ export class GameGateway {
   }
 
   @SubscribeMessage('joinGame')
-  async joinGame(@ConnectedSocket() client: Socket) {
-    this.lobbyManager.queue(client);
+  async joinGame(
+    @ConnectedSocket() client: Socket,
+    @MessageBody('mode') mode: string,
+  ) {
+    this.lobbyManager.queue(client, mode);
   }
 
   @SubscribeMessage('movePaddle')

--- a/containers/vuejs/src/components/GameHeader.vue
+++ b/containers/vuejs/src/components/GameHeader.vue
@@ -20,7 +20,7 @@ const startOfGame = ref(false)
 
 const joinGame = () => {
   buttonText.value = 'Seeking game...'
-  gameSocket.emit('joinGame')
+  gameSocket.emit('joinGame', { mode: 'normal' })
 }
 const reset = () => {
   buttonText.value = 'PLAY'

--- a/containers/vuejs/src/components/PongCanvas.vue
+++ b/containers/vuejs/src/components/PongCanvas.vue
@@ -53,15 +53,11 @@ const drawObject = (
   }
 }
 // TODO: Replace "any" with Data struct typedef?
-const render = (data: {
-  ball: any
-  leftPlayer: { paddle: any; score: number }
-  rightPlayer: { paddle: any; score: number }
-}) => {
+const render = (data: { rects: Array<any>; score: any }) => {
   drawCanvas()
-  drawObject('white', data.ball)
-  drawObject('white', data.leftPlayer.paddle)
-  drawObject('white', data.rightPlayer.paddle)
+  for (const rect of data.rects) {
+    drawObject(rect.color, rect)
+  }
 }
 
 onMounted(() => {

--- a/containers/vuejs/src/components/ScoreBoard.vue
+++ b/containers/vuejs/src/components/ScoreBoard.vue
@@ -22,9 +22,9 @@ gameSocket.on('gameStart', () => {
   startGame.value = true
 })
 gameSocket.on('pong', (data: any) => {
-  leftPlayerScore.value = data.leftPlayer.score
+  leftPlayerScore.value = data.score.leftPlayer
   // console.log('leftPlayerScore', leftPlayerScore.value)
-  rightPlayerScore.value = data.rightPlayer.score
+  rightPlayerScore.value = data.score.rightPlayer
   // console.log('rightPlayerScore', rightPlayerScore.value)
 })
 </script>


### PR DESCRIPTION
Added a second gamemode for Pong. This gamemode has the following items:
- `ReverseControlItem`:  The controls of the opponent are reversed for 3 hits.
- `InvisibleBallItem`: Makes the ball invisible until hit.
- `SmallerPaddleItem`: The size of the opponent their paddle is shrunk by 25% for 3 hits.

This pull request also contains a whole rewrite of the game logic, moving some of the core logic to the `APong` abstract class and moving other logic to the `NormalPong` class  that is extended from `APong`.

The new Pong gamemode is in a class named `SpecialPong` that extends form `APong`. 

Front-end should request a lobby for this new gamemode by calling `gamesocket.emit('joinGame', { mode: 'special' })`