### PR TITLE
Default database values

### DIFF
--- a/containers/nestjs/src/api/chat/chat.controller.ts
+++ b/containers/nestjs/src/api/chat/chat.controller.ts
@@ -1,6 +1,5 @@
 import { Body, Controller, Get, Param, Post, Request } from '@nestjs/common';
 import { ChatService } from '../../chat/chat.service';
-import { v4 as uuid } from 'uuid';
 import { IsEnum, IsNotEmpty, IsUUID } from 'class-validator';
 import { Visibility } from 'src/chat/chat.entity';
 
@@ -34,29 +33,13 @@ export class ChatController {
   constructor(private readonly chatService: ChatService) {}
 
   @Post('create')
-  async create(@Request() req, @Body() dto: CreateDto) {
-    const intra_id = req.user.intra_id;
-
-    // TODO: Throw error if visibility isn't PUBLIC/PROTECTED/PRIVATE
-
-    // TODO: Implement
-    const hashed_password =
-      dto.visibility === Visibility.PROTECTED
-        ? await this.chatService.hashPassword(dto.password)
-        : '';
-
-    return this.chatService.create(intra_id, {
-      chat_id: uuid(),
-      name: dto.name,
-      users: [intra_id],
-      history: [],
-      visibility: dto.visibility,
-      hashed_password: hashed_password,
-      owner: intra_id,
-      admins: [intra_id],
-      banned: [],
-      muted: [],
-    });
+  create(@Request() req, @Body() dto: CreateDto) {
+    return this.chatService.create(
+      req.user.intra_id,
+      dto.name,
+      dto.visibility,
+      dto.password,
+    );
   }
 
   @Get('chats')

--- a/containers/nestjs/src/auth/auth.service.ts
+++ b/containers/nestjs/src/auth/auth.service.ts
@@ -95,16 +95,7 @@ export class AuthService {
             console.log('Saved profile picture');
           });
 
-          this.usersService.create({
-            intra_id: intra_id,
-            username: j.displayname,
-            email: j.email,
-            isTwoFactorAuthenticationEnabled: false,
-            twoFactorAuthenticationSecret: null,
-            my_chats: [],
-            wins: 0,
-            losses: 0,
-          });
+          this.usersService.create(intra_id, j.displayname, j.email);
         }
 
         const payload = { sub: intra_id };

--- a/containers/nestjs/src/chat/chat.entity.ts
+++ b/containers/nestjs/src/chat/chat.entity.ts
@@ -37,7 +37,7 @@ export class Chat {
   @Column('int', { array: true })
   admins: number[];
 
-  @Column('int', { array: true })
+  @Column('int', { array: true, default: [] })
   banned: number[];
 
   @OneToMany(() => Mute, (mute) => mute.chat)

--- a/containers/nestjs/src/game/Lobby.ts
+++ b/containers/nestjs/src/game/Lobby.ts
@@ -29,7 +29,7 @@ export default class Lobby {
     private readonly usersService: UsersService,
   ) {
     console.log('Initializing lobby with mode:', mode);
-    console.log('gamemodes', this.gamemodes);
+    // console.log('gamemodes', this.gamemodes);
     this.pong = this.gamemodes.get(mode)(10);
   }
 

--- a/containers/nestjs/src/users/user.entity.ts
+++ b/containers/nestjs/src/users/user.entity.ts
@@ -12,7 +12,7 @@ export class User {
   @Column()
   email: string;
 
-  @Column()
+  @Column({ default: false })
   isTwoFactorAuthenticationEnabled: boolean;
 
   @Column({ nullable: true })
@@ -22,8 +22,8 @@ export class User {
   my_chats: MyChat[];
 
   @Column('int', { default: 0 })
-  wins: number = 0;
+  wins: number;
 
-  @Column('int')
-  losses: number = 0;
+  @Column('int', { default: 0 })
+  losses: number;
 }

--- a/containers/nestjs/src/users/users.service.ts
+++ b/containers/nestjs/src/users/users.service.ts
@@ -17,8 +17,12 @@ export class UsersService {
     private readonly myChatRepository: Repository<MyChat>,
   ) {}
 
-  create(user: User): Promise<User> {
-    return this.usersRepository.save(user);
+  create(intra_id: number, username: string, email: string): Promise<User> {
+    return this.usersRepository.save({
+      intra_id,
+      username,
+      email,
+    });
   }
 
   // TODO: Remove?
@@ -78,11 +82,11 @@ export class UsersService {
   }
 
   async addToChat(intra_id: number, chat_id: string, name: string) {
-    const myChat = new MyChat();
-    myChat.chat_id = chat_id;
-    myChat.name = name;
-    myChat.user = await this.findOne(intra_id);
-    await this.myChatRepository.save(myChat);
+    await this.myChatRepository.save({
+      chat_id,
+      name,
+      user: await this.findOne(intra_id),
+    });
   }
 
   getMyChats(intra_id: number): Promise<MyChat[]> {

--- a/containers/nestjs/test/public.e2e-spec.ts
+++ b/containers/nestjs/test/public.e2e-spec.ts
@@ -55,14 +55,7 @@ describe('App (e2e)', () => {
   });
 
   async function addUser() {
-    await usersService.create({
-      intra_id: intraId,
-      username: 'foo',
-      email: 'foo',
-      isTwoFactorAuthenticationEnabled: false,
-      twoFactorAuthenticationSecret: null,
-      my_chats: [],
-    });
+    await usersService.create(intraId, 'foo', 'foo');
   }
 
   function getPublic(path, expectedStatus, expectedBody) {


### PR DESCRIPTION
The trick to making default values work is that our UsersService and ChatService their create() functions can just take the non-default fields as arguments, rather than passing them an entire User and Chat class that *had* to have the default fields filled out manually.