### PR TITLE
Victor cleanup

### DIFF
--- a/containers/nestjs/src/api/chat/chat.gateway.ts
+++ b/containers/nestjs/src/api/chat/chat.gateway.ts
@@ -205,7 +205,7 @@ export class ChatGateway {
     @ConnectedSocket() client: Socket,
     @MessageBody() dto: ChatDto,
   ) {
-    this.chatSockets.removeFromChat(dto.chatId, client);
+    this.chatSockets.removeSocketFromChat(dto.chatId, client);
 
     return {};
   }

--- a/containers/nestjs/src/api/chat/chat.gateway.ts
+++ b/containers/nestjs/src/api/chat/chat.gateway.ts
@@ -32,6 +32,7 @@ import { UserService } from '../../user/user.service';
 import { Visibility } from '../../chat/chat.entity';
 import { BaseEntity } from 'typeorm';
 import { Transform, TransformFnParams } from 'class-transformer';
+import ChatSockets from 'src/chat/chat.sockets';
 
 @ValidatorConstraint({ async: true })
 @Injectable()
@@ -109,13 +110,11 @@ export class ChatGateway {
   @WebSocketServer()
   server!: Server;
 
-  private connectedClients = new Set<Socket>();
-  private chatToSockets = new Map<string, Set<Socket>>();
-
   constructor(
     private readonly chatService: ChatService,
     private readonly userService: UserService,
     private readonly transJwtService: TransJwtService,
+    private readonly chatSockets: ChatSockets,
   ) {}
 
   handleConnection(@ConnectedSocket() client: Socket) {
@@ -144,29 +143,11 @@ export class ChatGateway {
       });
     }
 
-    this.connectedClients.add(client);
+    this.chatSockets.add(client);
   }
 
   handleDisconnect(@ConnectedSocket() client: Socket) {
-    this.chatToSockets.forEach(async (sockets, chatId) => {
-      await this.removeChatSocket(sockets, client, chatId);
-    });
-
-    this.connectedClients.delete(client);
-  }
-
-  private async removeChatSocket(
-    sockets: Set<Socket>,
-    socket: Socket,
-    chatId: string,
-  ) {
-    if (sockets.has(socket)) {
-      sockets.delete(socket);
-    }
-
-    if (sockets.size <= 0) {
-      this.chatToSockets.delete(chatId);
-    }
+    this.chatSockets.disconnect(client);
   }
 
   @SubscribeMessage('create')
@@ -190,9 +171,7 @@ export class ChatGateway {
     client.emit('addMyChat', sentChat);
 
     if (chat.visibility !== Visibility.PRIVATE) {
-      for (const socket of this.connectedClients.values()) {
-        socket.emit('addChat', sentChat);
-      }
+      this.chatSockets.emitToAllSockets('addChat', sentChat);
     }
 
     return sentChat;
@@ -214,13 +193,7 @@ export class ChatGateway {
     @ConnectedSocket() client: Socket,
     @MessageBody() dto: ChatDto,
   ) {
-    if (!this.chatToSockets.has(dto.chatId)) {
-      this.chatToSockets.set(dto.chatId, new Set());
-    }
-
-    const sockets = this.chatToSockets.get(dto.chatId);
-
-    sockets.add(client);
+    this.chatSockets.addToChat(dto.chatId, client);
 
     await this.chatService.openChat(dto.chatId, client.data.intra_id);
 
@@ -232,11 +205,7 @@ export class ChatGateway {
     @ConnectedSocket() client: Socket,
     @MessageBody() dto: ChatDto,
   ) {
-    const sockets = this.chatToSockets.get(dto.chatId);
-
-    if (sockets) {
-      await this.removeChatSocket(sockets, client, dto.chatId);
-    }
+    this.chatSockets.removeFromChat(dto.chatId, client);
 
     return {};
   }
@@ -269,17 +238,11 @@ export class ChatGateway {
       date,
     );
 
-    const sockets = this.chatToSockets.get(dto.chatId) ?? [];
-
-    const senderName = await this.userService.getUsername(client.data.intra_id);
-
-    sockets.forEach((otherClient) => {
-      otherClient.emit('newMessage', {
-        sender: client.data.intra_id,
-        sender_name: senderName,
-        body,
-        date: date,
-      });
+    this.chatSockets.emitToChat(dto.chatId, 'newMessage', {
+      sender: client.data.intra_id,
+      sender_name: await this.userService.getUsername(client.data.intra_id),
+      body,
+      date: date,
     });
 
     return {};

--- a/containers/nestjs/src/chat/chat.module.ts
+++ b/containers/nestjs/src/chat/chat.module.ts
@@ -6,6 +6,7 @@ import { Message } from './message.entity';
 import { Mute } from './mute.entity';
 import { ChatService } from './chat.service';
 import { UserModule } from '../user/user.module';
+import ChatSockets from './chat.sockets';
 
 @Module({
   imports: [
@@ -13,7 +14,7 @@ import { UserModule } from '../user/user.module';
     UserModule,
     TypeOrmModule.forFeature([Chat, Message, Mute]),
   ],
-  providers: [ChatService],
-  exports: [ChatService],
+  providers: [ChatService, ChatSockets],
+  exports: [ChatService, ChatSockets],
 })
 export class ChatModule {}

--- a/containers/nestjs/src/chat/chat.service.ts
+++ b/containers/nestjs/src/chat/chat.service.ts
@@ -22,6 +22,12 @@ import { UserService } from '../user/user.service';
 import { WsException } from '@nestjs/websockets';
 import ChatSockets from './chat.sockets';
 
+class ChatClass {
+  chat_id: string;
+  name: string;
+  visibility: Visibility;
+}
+
 class MyInfo {
   owner: boolean;
   admin: boolean;
@@ -667,6 +673,12 @@ export class ChatService {
 
       chat.users = chat.users.filter((u) => u.intra_id !== intra_id);
 
+      const sentChat: ChatClass = {
+        chat_id: chat.chat_id,
+        name: chat.name,
+        visibility: chat.visibility,
+      };
+
       if (chat.owner.intra_id == intra_id) {
         if (chat.admins.length > 0) {
           chat.owner = chat.admins[0];
@@ -675,13 +687,13 @@ export class ChatService {
           chat.admins.push(chat.users[0]);
         } else {
           await this.removeChat(chat);
-          this.chatSockets.emitToClient(intra_id, 'leaveChat', chat_id);
+          this.chatSockets.emitToClient(intra_id, 'leaveChat', sentChat);
           this.chatSockets.emitToAllSockets('removeChat', chat_id);
           return;
         }
       }
 
-      this.chatSockets.emitToClient(intra_id, 'leaveChat', chat_id);
+      this.chatSockets.emitToClient(intra_id, 'leaveChat', sentChat);
 
       await this.chatRepository.save(chat);
     });

--- a/containers/nestjs/src/chat/chat.service.ts
+++ b/containers/nestjs/src/chat/chat.service.ts
@@ -322,6 +322,11 @@ export class ChatService {
       await this.chatRepository.save(chat);
 
       this.chatSockets.emitToChat(chat_id, 'removeUser', banned_id);
+      this.chatSockets.emitToClient(banned_id, 'banned', {
+        chat_id: chat_id,
+        name: chat.name,
+        visibility: chat.visibility,
+      });
     });
   }
 
@@ -355,6 +360,11 @@ export class ChatService {
       await this.chatRepository.save(chat);
 
       this.chatSockets.emitToChat(chat_id, 'removeUser', kicked_id);
+      this.chatSockets.emitToClient(kicked_id, 'kicked', {
+        chat_id: chat_id,
+        name: chat.name,
+        visibility: chat.visibility,
+      });
     });
   }
 

--- a/containers/nestjs/src/chat/chat.service.ts
+++ b/containers/nestjs/src/chat/chat.service.ts
@@ -321,7 +321,7 @@ export class ChatService {
 
       await this.chatRepository.save(chat);
 
-      return { intra_id: banned_id, is_banned: true };
+      this.chatSockets.emitToChat(chat_id, 'removeUser', banned_id);
     });
   }
 
@@ -354,15 +354,7 @@ export class ChatService {
 
       await this.chatRepository.save(chat);
 
-      return { intra_id: kicked_id, is_kicked: true };
-
-      // if (chat.owner.intra_id == kicker_id) return false;
-
-      // chat.users = chat.users.filter((u) => u.intra_id !== kicker_id);
-      // chat.admins = chat.admins.filter((u) => u.intra_id !== kicker_id);
-      // const result = await this.chatRepository.save(chat);
-
-      // return !!result;
+      this.chatSockets.emitToChat(chat_id, 'removeUser', kicked_id);
     });
   }
 

--- a/containers/nestjs/src/chat/chat.service.ts
+++ b/containers/nestjs/src/chat/chat.service.ts
@@ -696,6 +696,7 @@ export class ChatService {
       }
 
       this.chatSockets.emitToClient(intra_id, 'leaveChat', sentChat);
+      this.chatSockets.emitToChat(chat_id, 'removeUser', intra_id);
 
       await this.chatRepository.save(chat);
     });

--- a/containers/nestjs/src/chat/chat.service.ts
+++ b/containers/nestjs/src/chat/chat.service.ts
@@ -675,10 +675,13 @@ export class ChatService {
           chat.admins.push(chat.users[0]);
         } else {
           await this.removeChat(chat);
+          this.chatSockets.emitToClient(intra_id, 'leaveChat', chat_id);
           this.chatSockets.emitToAllSockets('removeChat', chat_id);
           return;
         }
       }
+
+      this.chatSockets.emitToClient(intra_id, 'leaveChat', chat_id);
 
       await this.chatRepository.save(chat);
     });

--- a/containers/nestjs/src/chat/chat.service.ts
+++ b/containers/nestjs/src/chat/chat.service.ts
@@ -614,7 +614,7 @@ export class ChatService {
     chat_id: string,
     intra_id: number,
     edit_fields: EditFields,
-  ): Promise<EditFields> {
+  ) {
     return await this.getChat({ chat_id }, { owner: true }).then(
       async (chat) => {
         if (intra_id !== chat.owner.intra_id) {
@@ -666,9 +666,12 @@ export class ChatService {
           }
           chat.hashed_password = await this.hashPassword(edit_fields.password);
         }
-        // TODO: Sent this update to all sockets
         await this.chatRepository.save(chat);
-        return { name: edit_fields.name, visibility: edit_fields.visibility };
+        this.chatSockets.emitToAllSockets('editChatInfo', {
+          chat_id: chat.chat_id,
+          name: chat.name,
+          visibility: chat.visibility,
+        });
       },
     );
   }

--- a/containers/nestjs/src/chat/chat.service.ts
+++ b/containers/nestjs/src/chat/chat.service.ts
@@ -194,6 +194,8 @@ export class ChatService {
           throw new WsException('You have been banned from this chat');
         }
 
+        this.chatSockets.emitToChat(chat_id, 'addUser', user);
+
         chat.users.push(user);
         await this.chatRepository.save(chat);
       },

--- a/containers/nestjs/src/chat/chat.service.ts
+++ b/containers/nestjs/src/chat/chat.service.ts
@@ -321,6 +321,7 @@ export class ChatService {
 
       await this.chatRepository.save(chat);
 
+      this.chatSockets.removeUserFromChat(chat_id, banned_id);
       this.chatSockets.emitToChat(chat_id, 'removeUser', banned_id);
       this.chatSockets.emitToClient(banned_id, 'banned', {
         chat_id: chat_id,
@@ -359,6 +360,7 @@ export class ChatService {
 
       await this.chatRepository.save(chat);
 
+      this.chatSockets.removeUserFromChat(chat_id, kicked_id);
       this.chatSockets.emitToChat(chat_id, 'removeUser', kicked_id);
       this.chatSockets.emitToClient(kicked_id, 'kicked', {
         chat_id: chat_id,
@@ -697,6 +699,8 @@ export class ChatService {
         }
       }
 
+      // TODO: Find out why this is not needed. I expect a user to still enter the `newMessage` event on the front end without this line but they don't. This line is needed in the kickUser() and banUser() functions.
+      this.chatSockets.removeUserFromChat(chat_id, intra_id);
       this.chatSockets.emitToClient(intra_id, 'leaveChat', sentChat);
       this.chatSockets.emitToChat(chat_id, 'removeUser', intra_id);
 

--- a/containers/nestjs/src/chat/chat.service.ts
+++ b/containers/nestjs/src/chat/chat.service.ts
@@ -658,6 +658,10 @@ export class ChatService {
         muted: true,
       },
     ).then(async (chat) => {
+      if (!chat.users.some((user) => user.intra_id === intra_id)) {
+        throw new UnauthorizedException('You are not in this chat');
+      }
+
       if (chat.admins.some((admin) => admin.intra_id == intra_id))
         chat.admins = chat.admins.filter((u) => u.intra_id !== intra_id);
 

--- a/containers/nestjs/src/chat/chat.service.ts
+++ b/containers/nestjs/src/chat/chat.service.ts
@@ -20,6 +20,7 @@ import { Message } from './message.entity';
 import { Mute } from './mute.entity';
 import { UserService } from '../user/user.service';
 import { WsException } from '@nestjs/websockets';
+import ChatSockets from './chat.sockets';
 
 class MyInfo {
   owner: boolean;
@@ -51,6 +52,7 @@ export class ChatService {
     @InjectRepository(Mute) private readonly muteRepository: Repository<Mute>,
     private readonly userService: UserService,
     private readonly configService: ConfigService,
+    private readonly chatSockets: ChatSockets,
   ) {}
 
   public async create(
@@ -669,6 +671,7 @@ export class ChatService {
           chat.admins.push(chat.users[0]);
         } else {
           await this.removeChat(chat);
+          this.chatSockets.emitToAllSockets('removeChat', chat_id);
           return;
         }
       }

--- a/containers/nestjs/src/chat/chat.sockets.ts
+++ b/containers/nestjs/src/chat/chat.sockets.ts
@@ -76,4 +76,14 @@ export default class ChatSockets {
       });
     }
   }
+
+  public emitToClient(intra_id: number, event: string, body: any) {
+    const sockets = this.clientToSockets.get(intra_id);
+
+    if (sockets) {
+      sockets.forEach((otherClient) => {
+        otherClient.emit(event, body);
+      });
+    }
+  }
 }

--- a/containers/nestjs/src/chat/chat.sockets.ts
+++ b/containers/nestjs/src/chat/chat.sockets.ts
@@ -26,10 +26,24 @@ export default class ChatSockets {
     sockets.add(client);
   }
 
-  public removeFromChat(chatId: string, client: Socket) {
+  public removeSocketFromChat(chatId: string, client: Socket) {
     let sockets = this.chatToSockets.get(chatId);
     if (sockets) {
       sockets.delete(client);
+      if (sockets.size <= 0) {
+        this.chatToSockets.delete(chatId);
+      }
+    }
+  }
+
+  public removeUserFromChat(chatId: string, intra_id: number) {
+    let sockets = this.chatToSockets.get(chatId);
+    if (sockets) {
+      sockets.forEach((socket) => {
+        if (socket.data.intra_id === intra_id) {
+          sockets.delete(socket);
+        }
+      });
       if (sockets.size <= 0) {
         this.chatToSockets.delete(chatId);
       }
@@ -49,7 +63,7 @@ export default class ChatSockets {
     }
 
     this.chatToSockets.forEach((_sockets, chatId) => {
-      this.removeFromChat(chatId, client);
+      this.removeSocketFromChat(chatId, client);
     });
   }
 

--- a/containers/nestjs/src/chat/chat.sockets.ts
+++ b/containers/nestjs/src/chat/chat.sockets.ts
@@ -1,0 +1,79 @@
+import { Socket } from 'socket.io';
+
+export default class ChatSockets {
+  private readonly connectedClients = new Set<Socket>();
+  private readonly clientToSockets = new Map<number, Set<Socket>>();
+  private readonly chatToSockets = new Map<string, Set<Socket>>();
+
+  public add(client: Socket) {
+    this.connectedClients.add(client);
+
+    const intra_id = client.data.intra_id;
+    let sockets = this.clientToSockets.get(intra_id);
+    if (!sockets) {
+      sockets = new Set();
+      this.clientToSockets.set(intra_id, sockets);
+    }
+    sockets.add(client);
+  }
+
+  public addToChat(chatId: string, client: Socket) {
+    let sockets = this.chatToSockets.get(chatId);
+    if (!sockets) {
+      sockets = new Set();
+      this.chatToSockets.set(chatId, sockets);
+    }
+    sockets.add(client);
+  }
+
+  public removeFromChat(chatId: string, client: Socket) {
+    let sockets = this.chatToSockets.get(chatId);
+    if (sockets) {
+      sockets.delete(client);
+      if (sockets.size <= 0) {
+        this.chatToSockets.delete(chatId);
+      }
+    }
+  }
+
+  public disconnect(client: Socket) {
+    this.connectedClients.delete(client);
+
+    const intra_id = client.data.intra_id;
+    const clientSockets = this.clientToSockets.get(intra_id);
+    if (clientSockets) {
+      clientSockets.delete(client);
+      if (clientSockets.size <= 0) {
+        this.clientToSockets.delete(intra_id);
+      }
+    }
+
+    this.chatToSockets.forEach((_sockets, chatId) => {
+      this.removeFromChat(chatId, client);
+    });
+  }
+
+  //   public get(intra_id: number): Socket[] {
+  //     return this.clients.get(intra_id) ?? [];
+  //   }
+
+  //   public getAll(): Socket[] {
+  //     return this.clients;
+  //   }
+
+  public emitToAllSockets(event: string, body: any) {
+    for (const socket of this.connectedClients.values()) {
+      socket.emit(event, body);
+    }
+  }
+
+  public emitToChat(chatId: string, event: string, body: any) {
+    const sockets = this.chatToSockets.get(chatId);
+
+    if (sockets) {
+      sockets.forEach((otherClient) => {
+        otherClient.emit(event, body);
+      });
+    }
+  }
+}

--- a/containers/vuejs/src/components/Chat.vue
+++ b/containers/vuejs/src/components/Chat.vue
@@ -282,15 +282,25 @@ async function getChats() {
   })
 }
 
-chatSocket.on('addMyChat', async (chat: Chat) => {
+chatSocket.on('addMyChat', (chat: Chat) => {
   myChats.value.push(chat)
 })
-chatSocket.on('addChat', async (chat: Chat) => {
+chatSocket.on('addChat', (chat: Chat) => {
   if (chat.visibility !== Visibility.PRIVATE) {
     publicAndProtectedChats.value.push(chat)
   }
 })
-chatSocket.on('removeChat', async (chat: Chat) => {})
+chatSocket.on('removeChat', (chat_id: string) => {
+  let index = myChats.value.findIndex((chat) => chat.chat_id === chat_id)
+  if (index !== -1) {
+    myChats.value.splice(index, 1)
+  }
+
+  index = publicAndProtectedChats.value.findIndex((chat) => chat.chat_id === chat_id)
+  if (index !== -1) {
+    publicAndProtectedChats.value.splice(index, 1)
+  }
+})
 
 chatSocket.on('exception', (data) => {
   alertPopup.value.showWarning(data.message)

--- a/containers/vuejs/src/components/Chat.vue
+++ b/containers/vuejs/src/components/Chat.vue
@@ -315,10 +315,16 @@ chatSocket.on('removeChat', (chat_id: string) => {
   }
 })
 
-chatSocket.on('leaveChat', (chat_id: string) => {
-  const index = myChats.value.findIndex((chat) => chat.chat_id === chat_id)
+chatSocket.on('leaveChat', (chat: Chat) => {
+  const index = myChats.value.findIndex((chat) => chat.chat_id === chat.chat_id)
   if (index !== -1) {
     myChats.value.splice(index, 1)
+  }
+
+  if (chat.visibility === Visibility.PUBLIC || chat.visibility === Visibility.PROTECTED) {
+    if (!publicAndProtectedChats.value.some((other) => other.chat_id === chat.chat_id)) {
+      publicAndProtectedChats.value.push(chat)
+    }
   }
 })
 

--- a/containers/vuejs/src/components/Chat.vue
+++ b/containers/vuejs/src/components/Chat.vue
@@ -358,6 +358,19 @@ chatSocket.on('banned', (chat: Chat) => {
   }
 })
 
+chatSocket.on('editChatInfo', (chat: Chat) => {
+  let foundChat = myChats.value.find((other) => other.chat_id === chat.chat_id)
+  if (foundChat === undefined) {
+    foundChat = publicAndProtectedChats.value.find((other) => other.chat_id === chat.chat_id)
+    if (foundChat === undefined) {
+      return
+    }
+  }
+
+  foundChat.name = chat.name
+  foundChat.visibility = chat.visibility
+})
+
 chatSocket.on('exception', (data) => {
   alertPopup.value.showWarning(data.message)
 })

--- a/containers/vuejs/src/components/Chat.vue
+++ b/containers/vuejs/src/components/Chat.vue
@@ -301,20 +301,24 @@ async function getChats() {
 chatSocket.on('addMyChat', (chat: Chat) => {
   myChats.value.push(chat)
 })
+
 chatSocket.on('addChat', (chat: Chat) => {
   if (chat.visibility !== Visibility.PRIVATE) {
     publicAndProtectedChats.value.push(chat)
   }
 })
-chatSocket.on('removeChat', (chat_id: string) => {
-  let index = myChats.value.findIndex((chat) => chat.chat_id === chat_id)
-  if (index !== -1) {
-    myChats.value.splice(index, 1)
-  }
 
-  index = publicAndProtectedChats.value.findIndex((chat) => chat.chat_id === chat_id)
+chatSocket.on('removeChat', (chat_id: string) => {
+  const index = publicAndProtectedChats.value.findIndex((chat) => chat.chat_id === chat_id)
   if (index !== -1) {
     publicAndProtectedChats.value.splice(index, 1)
+  }
+})
+
+chatSocket.on('leaveChat', (chat_id: string) => {
+  const index = myChats.value.findIndex((chat) => chat.chat_id === chat_id)
+  if (index !== -1) {
+    myChats.value.splice(index, 1)
   }
 })
 

--- a/containers/vuejs/src/components/Chat.vue
+++ b/containers/vuejs/src/components/Chat.vue
@@ -243,6 +243,13 @@ function openChat(chat: Chat) {
 function clickedPublicChat(chat: Chat) {
   chatSocket.emit('joinChat', { chatId: chat.chat_id }, () => {
     openChat(chat)
+
+    const index = publicAndProtectedChats.value.findIndex((other) => other.chat_id === chat.chat_id)
+    if (index !== -1) {
+      publicAndProtectedChats.value.splice(index, 1)
+    }
+
+    myChats.value.push(chat)
   })
 }
 
@@ -267,6 +274,15 @@ function enterProtectedChat(password_: string) {
     passwordModal.value.$.exposed.hide()
 
     openChat(selectedChat.value!)
+
+    const index = publicAndProtectedChats.value.findIndex(
+      (chat) => chat.chat_id === selectedChat.value!.chat_id
+    )
+    if (index !== -1) {
+      publicAndProtectedChats.value.splice(index, 1)
+    }
+
+    myChats.value.push(selectedChat.value!)
 
     selectedChat.value = null
   })

--- a/containers/vuejs/src/components/Chat.vue
+++ b/containers/vuejs/src/components/Chat.vue
@@ -328,6 +328,36 @@ chatSocket.on('leaveChat', (chat: Chat) => {
   }
 })
 
+chatSocket.on('kicked', (chat: Chat) => {
+  currentChat.value = null
+
+  const index = myChats.value.findIndex((chat) => chat.chat_id === chat.chat_id)
+  if (index !== -1) {
+    myChats.value.splice(index, 1)
+  }
+
+  if (chat.visibility === Visibility.PUBLIC || chat.visibility === Visibility.PROTECTED) {
+    if (!publicAndProtectedChats.value.some((other) => other.chat_id === chat.chat_id)) {
+      publicAndProtectedChats.value.push(chat)
+    }
+  }
+})
+
+chatSocket.on('banned', (chat: Chat) => {
+  currentChat.value = null
+
+  const index = myChats.value.findIndex((chat) => chat.chat_id === chat.chat_id)
+  if (index !== -1) {
+    myChats.value.splice(index, 1)
+  }
+
+  if (chat.visibility === Visibility.PUBLIC || chat.visibility === Visibility.PROTECTED) {
+    if (!publicAndProtectedChats.value.some((other) => other.chat_id === chat.chat_id)) {
+      publicAndProtectedChats.value.push(chat)
+    }
+  }
+})
+
 chatSocket.on('exception', (data) => {
   alertPopup.value.showWarning(data.message)
 })

--- a/containers/vuejs/src/components/chat/ChatUserListModal.vue
+++ b/containers/vuejs/src/components/chat/ChatUserListModal.vue
@@ -119,12 +119,8 @@ defineExpose({
 })
 
 const myInfo = ref<MyInfo>(await get(`api/chats/${props.currentChat?.chat_id}/me`))
-const users = ref<UserInfo[]>(await get(`api/chats/${props.currentChat?.chat_id}/users`))
 
-// TODO: Remove this
-// for (let i = 0; i < 100; i++) {
-//   users.value.push(users.value[0])
-// }
+const users = ref<UserInfo[]>(await get(`api/chats/${props.currentChat?.chat_id}/users`))
 
 const profilePictures = ref(new Map<UserInfo['intra_id'], string>())
 users.value.forEach(
@@ -134,6 +130,16 @@ users.value.forEach(
       await getImage(`api/user/profilePicture/${user.intra_id}`)
     )
 )
+
+chatSocket.on('addUser', async (user: UserInfo) => {
+  if (!users.value.some((other) => other.intra_id === user.intra_id)) {
+    profilePictures.value.set(
+      user.intra_id,
+      await getImage(`api/user/profilePicture/${user.intra_id}`)
+    )
+    users.value.push(user)
+  }
+})
 
 const selectedUser = ref<UserInfo>()
 

--- a/containers/vuejs/src/components/chat/ChatUserListModal.vue
+++ b/containers/vuejs/src/components/chat/ChatUserListModal.vue
@@ -188,25 +188,17 @@ async function unmute() {
 async function kick() {
   await post(`api/chats/${props.currentChat?.chat_id}/kick`, {
     intra_id: selectedUser.value?.intra_id
+  }).catch((err) => {
+    alertPopup.value.showWarning(err.response.data.message)
   })
-    .then((res) => {
-      users.value = users.value.filter((user) => user.intra_id !== res.intra_id)
-    })
-    .catch((err) => {
-      alertPopup.value.showWarning(err.response.data.message)
-    })
 }
 
 async function ban() {
   await post(`api/chats/${props.currentChat?.chat_id}/ban`, {
     intra_id: selectedUser.value?.intra_id
+  }).catch((err) => {
+    alertPopup.value.showWarning(err.response.data.message)
   })
-    .then((res) => {
-      users.value = users.value.filter((user) => user.intra_id !== res.intra_id)
-    })
-    .catch((err) => {
-      alertPopup.value.showWarning(err.response.data.message)
-    })
 }
 
 async function admin() {

--- a/containers/vuejs/src/components/chat/ChatUserListModal.vue
+++ b/containers/vuejs/src/components/chat/ChatUserListModal.vue
@@ -141,6 +141,13 @@ chatSocket.on('addUser', async (user: UserInfo) => {
   }
 })
 
+chatSocket.on('removeUser', (intra_id: number) => {
+  const index = users.value.findIndex((user) => user.intra_id === intra_id)
+  if (index !== -1) {
+    users.value.splice(index, 1)
+  }
+})
+
 const selectedUser = ref<UserInfo>()
 
 const modal = ref()

--- a/containers/vuejs/src/components/chat/ChatUserListModal.vue
+++ b/containers/vuejs/src/components/chat/ChatUserListModal.vue
@@ -94,10 +94,10 @@ import ChatMuteModal from './ChatMuteModal.vue'
 
 type UserInfo = {
   intra_id: number
-  username: string
-  is_owner: boolean
-  is_admin: boolean
-  is_mute: boolean
+  username?: string
+  is_owner?: boolean
+  is_admin?: boolean
+  is_mute?: boolean
 }
 
 const chatMuteModal = ref()
@@ -148,6 +148,22 @@ chatSocket.on('removeUser', (intra_id: number) => {
   }
 })
 
+chatSocket.on('editUserInfo', (info: UserInfo) => {
+  const user = users.value.find((user) => user.intra_id === info.intra_id)
+  if (user === undefined) {
+    return
+  }
+  if (info.is_owner !== undefined) {
+    user.is_owner = info.is_owner
+  }
+  if (info.is_admin !== undefined) {
+    user.is_admin = info.is_admin
+  }
+  if (info.is_mute !== undefined) {
+    user.is_mute = info.is_mute
+  }
+})
+
 const selectedUser = ref<UserInfo>()
 
 const modal = ref()
@@ -156,33 +172,17 @@ async function mute(endDate: Date) {
   await post(`api/chats/${props.currentChat?.chat_id}/mute`, {
     intra_id: selectedUser.value?.intra_id,
     endDate
+  }).catch((err) => {
+    alertPopup.value.showWarning(err.response.data.message)
   })
-    .then((res) => {
-      users.value.forEach((user) => {
-        if (user.intra_id === res.intra_id) {
-          user.is_mute = true
-        }
-      })
-    })
-    .catch((err) => {
-      alertPopup.value.showWarning(err.response.data.message)
-    })
 }
 
 async function unmute() {
   await post(`api/chats/${props.currentChat?.chat_id}/unmute`, {
     intra_id: selectedUser.value?.intra_id
+  }).catch((err) => {
+    alertPopup.value.showWarning(err.response.data.message)
   })
-    .then((res) => {
-      users.value.forEach((user) => {
-        if (user.intra_id === res.intra_id) {
-          user.is_mute = false
-        }
-      })
-    })
-    .catch((err) => {
-      alertPopup.value.showWarning(err.response.data.message)
-    })
 }
 
 async function kick() {
@@ -204,33 +204,17 @@ async function ban() {
 async function admin() {
   await post(`api/chats/${props.currentChat?.chat_id}/admin`, {
     intra_id: selectedUser.value?.intra_id
+  }).catch((err) => {
+    alertPopup.value.showWarning(err.response.data.message)
   })
-    .then((res) => {
-      users.value.forEach((user) => {
-        if (user.intra_id === res.intra_id) {
-          user.is_admin = true
-        }
-      })
-    })
-    .catch((err) => {
-      alertPopup.value.showWarning(err.response.data.message)
-    })
 }
 
 async function unAdmin() {
   await post(`api/chats/${props.currentChat?.chat_id}/unadmin`, {
     intra_id: selectedUser.value?.intra_id
+  }).catch((err) => {
+    alertPopup.value.showWarning(err.response.data.message)
   })
-    .then((res) => {
-      users.value.forEach((user) => {
-        if (user.intra_id === res.intra_id) {
-          user.is_admin = false
-        }
-      })
-    })
-    .catch((err) => {
-      alertPopup.value.showWarning(err.response.data.message)
-    })
 }
 
 const emit = defineEmits(['onCloseUserListModal'])


### PR DESCRIPTION
✅ Chat is added or removed
Send the 'addChat' or 'removeChat' event to everyone's sockets (socket Set)

✅ User leaves or joins chat
Send the 'left' or 'join' event to the sockets of every user in the chat (chat_id key)

Send the 'left' or 'join' event to all sockets of that user (intra_id key)

✅ User is banned or kicked
Send the 'banned' event to all of the banned user's sockets (intra_id key)

The event can't just be sent to all of the banned user's sockets that are inside of the chat, since the chat should also disappear from all of the banned user's lists

✅ User is made admin or owner or muted
Send the 'madeAdmin' or 'madeOwner' or 'muted' or event to the sockets of every user in the chat (chat_id key)

Also made chat information update live if something got edited (name/visibility)
